### PR TITLE
Implemented keybinder_set_avoid_cooking_shift_accelerators to fix Shift problems

### DIFF
--- a/libkeybinder/keybinder.h
+++ b/libkeybinder/keybinder.h
@@ -32,6 +32,8 @@ typedef void (* KeybinderHandler) (const char *keystring, void *user_data);
 
 void keybinder_init (void);
 
+void keybinder_set_avoid_cooking_shift_accelerators (gboolean avoid_cooking_shift);
+
 gboolean keybinder_bind (const char *keystring,
                          KeybinderHandler  handler,
                          void *user_data);

--- a/python-keybinder/_keybinder.defs
+++ b/python-keybinder/_keybinder.defs
@@ -34,6 +34,23 @@
 	"Will raise KeyError if keystring is not bound.")
 )
 
+(define-function set_avoid_cooking_shift_accelerators
+  (c-name "keybinder_set_avoid_cooking_shift_accelerators")
+  (return-type "none")
+  (parameters
+    '("bool" "avoid_cooking_shift")
+  )
+  (docstring "set_avoid_cooking_shift_accelerators (avoid_cooking_shift)\n"
+    "'Cooked' accelerators use symbols produced by using modifiers such\n"
+    "as shift or altgr, for example if '!' is produced by 'Shift+1',\n"
+    "thus binding Shift+1 may not work as expected.\n"
+    "Enabling this workaround will make Shift+1 work, but it could cause\n"
+    "issues on some keymaps where '!' is an actual key.\n"
+    "Default: Enabled.\n"
+    "\n"
+    "Will raise KeyError if avoid_cooking_shift is not bool.")
+)
+
 (define-function get_current_event_time
   (c-name "keybinder_get_current_event_time")
   (return-type "guint32")

--- a/python-keybinder/_keybinder.override
+++ b/python-keybinder/_keybinder.override
@@ -139,3 +139,28 @@ _wrap_keybinder_unbind (PyGObject *self, PyObject *args, PyObject *kwargs)
 	PyErr_SetString(PyExc_KeyError, "bind: keystring is not bound");
 	return NULL;
 }
+%%
+override keybinder_set_avoid_cooking_shift_accelerators kwargs
+static PyObject*
+_wrap_keybinder_set_avoid_cooking_shift_accelerators (PyGObject *self, PyObject *args, PyObject *kwargs)
+{
+	guint len;
+	len = PyTuple_Size(args);
+	if (len != 1) {
+		PyErr_SetString(PyExc_TypeError, "set_avoid_cooking_shift_accelerators requires exactly 1 argument");
+		return NULL;
+	}
+
+	PyObject *pyBoolean = PyTuple_GetItem( args, 0 );
+	int boolArg = PyObject_IsTrue( pyBoolean );
+
+	if( boolArg < 0 )
+	{
+		PyErr_SetString(PyExc_TypeError, "set_avoid_cooking_shift_accelerators must use a Boolean argument");
+		return NULL;
+	}
+
+	keybinder_set_avoid_cooking_shift_accelerators( (gboolean)boolArg );
+
+	return Py_None;
+}


### PR DESCRIPTION
Implements keybinder_set_avoid_cooking_shift_accelerators for the master branch using GTK 2.0 (which has a similar behavior as keybinder-3.0 keybinder_set_use_cooked_accelerators). Enabled by default to make Shift modifiers work.

Included Python bindings to toggle this function.